### PR TITLE
fix(stripe): add missing return

### DIFF
--- a/lib/payments/stripe.ts
+++ b/lib/payments/stripe.ts
@@ -17,6 +17,7 @@ export async function createCheckoutSession({
 }) {
   if (!user) {
     redirect(`/sign-up?redirect=checkout&priceId=${priceId}`);
+    return;
   }
 
   const session = await stripe.checkout.sessions.create({


### PR DESCRIPTION
Spotted it while randomly browsing the code. This is to avoid the rest of the function to be executed.