### PR TITLE
Remove duplicate HTML/body tags

### DIFF
--- a/app/(dashboard)/dashboard/layout.tsx
+++ b/app/(dashboard)/dashboard/layout.tsx
@@ -8,7 +8,6 @@ export default function DashboardLayout({
   return (
     <div className="flex flex-col min-h-[calc(100dvh-68px)] max-w-7xl mx-auto w-full">
       <div className="flex flex-1 overflow-hidden h-full">
-        {/* Main content */}
         <main className="flex-1 overflow-y-auto p-0 lg:p-4">{children}</main>
       </div>
     </div>

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -11,42 +11,38 @@ import { Toaster } from "@/components/ui/toaster";
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <ClerkProvider>
-      <html lang="en">
-        <body>
-          <header className="border-b border-gray-200">
-            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex justify-between items-center">
-              <SignedIn>
-                <Link href="/dashboard" className="flex items-center">
-                  <span className="ml-2 font-semibold text-gray-900 flex items-center">
-                    <span className="text-2xl transform scale-y-75">S</span>
-                    <span className="text-xl">hortest</span>
-                  </span>
-                </Link>
-              </SignedIn>
-              <SignedOut>
-                <Link href="/" className="flex items-center">
-                  <span className="ml-2 font-semibold text-gray-900 flex items-center">
-                    <span className="text-2xl transform scale-y-75">S</span>
-                    <span className="text-xl">hortest</span>
-                  </span>
-                </Link>
-              </SignedOut>
-              <div className="flex items-center space-x-4">
-                <SignedOut>
-                  <Link href="/pricing">Pricing</Link>
-                  <SignInButton />
-                </SignedOut>
-                <SignedIn>
-                  <Link href="/dashboard/settings">Settings</Link>
-                  <UserButton />
-                </SignedIn>
-              </div>
-            </div>
-          </header>
-          <main>{children}</main>
-          <Toaster />
-        </body>
-      </html>
+      <header className="border-b border-gray-200">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex justify-between items-center">
+          <SignedIn>
+            <Link href="/dashboard" className="flex items-center">
+              <span className="ml-2 font-semibold text-gray-900 flex items-center">
+                <span className="text-2xl transform scale-y-75">S</span>
+                <span className="text-xl">hortest</span>
+              </span>
+            </Link>
+          </SignedIn>
+          <SignedOut>
+            <Link href="/" className="flex items-center">
+              <span className="ml-2 font-semibold text-gray-900 flex items-center">
+                <span className="text-2xl transform scale-y-75">S</span>
+                <span className="text-xl">hortest</span>
+              </span>
+            </Link>
+          </SignedOut>
+          <div className="flex items-center space-x-4">
+            <SignedOut>
+              <Link href="/pricing">Pricing</Link>
+              <SignInButton />
+            </SignedOut>
+            <SignedIn>
+              <Link href="/dashboard/settings">Settings</Link>
+              <UserButton />
+            </SignedIn>
+          </div>
+        </div>
+      </header>
+      <main>{children}</main>
+      <Toaster />
     </ClerkProvider>
   );
 }

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -42,7 +42,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
           </div>
         </div>
       </header>
-      <main>{children}</main>
+      {children}
       <Toaster />
     </ClerkProvider>
   );

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -8,6 +8,13 @@ import {
 import Link from "next/link";
 import { Toaster } from "@/components/ui/toaster";
 
+const Logo = () => (
+  <span className="ml-2 font-semibold text-gray-900 flex items-center">
+    <span className="text-2xl transform scale-y-75">S</span>
+    <span className="text-xl">hortest</span>
+  </span>
+);
+
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <ClerkProvider>
@@ -15,18 +22,12 @@ export default function Layout({ children }: { children: React.ReactNode }) {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex justify-between items-center">
           <SignedIn>
             <Link href="/dashboard" className="flex items-center">
-              <span className="ml-2 font-semibold text-gray-900 flex items-center">
-                <span className="text-2xl transform scale-y-75">S</span>
-                <span className="text-xl">hortest</span>
-              </span>
+              <Logo />
             </Link>
           </SignedIn>
           <SignedOut>
             <Link href="/" className="flex items-center">
-              <span className="ml-2 font-semibold text-gray-900 flex items-center">
-                <span className="text-2xl transform scale-y-75">S</span>
-                <span className="text-xl">hortest</span>
-              </span>
+              <Logo />
             </Link>
           </SignedOut>
           <div className="flex items-center space-x-4">

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 
 export default function HomePage() {
   return (
-    <div className="main">
+    <main>
       <section className="py-20">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center">
@@ -140,6 +140,6 @@ export default function HomePage() {
           </div>
         </div>
       </section>
-    </div>
+    </main>
   );
 }


### PR DESCRIPTION
Short PR to remove duplicate HTML and body tags from the dashboard layout (8f529bca7f253ec7bd97441278fe52ba2773e2dc), as they are already present in `app/layout.tsx`.

https://github.com/gumroad/shortest/blob/9b117cce076c7057501e1fd14b36779c55d45b4f/app/layout.tsx#L21-L28

It also includes minor refactoring:
- ec980346abb8ad6c4bb7c346a9244d93b8f88f7f Moves logo into it's own component for consistency if/when updated.
- 96c0c77a3f7f3bf946b47f743b271e4b0eec885d Adjusted `main` elements to match content with the html/body removal.