### PR TITLE
feat: basic filtering

### DIFF
--- a/app/(dashboard)/dashboard/pull-request-filter.tsx
+++ b/app/(dashboard)/dashboard/pull-request-filter.tsx
@@ -1,0 +1,148 @@
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { ChevronDownIcon } from "lucide-react";
+
+interface FilterOptionProps {
+  id: string;
+  label: string;
+  checked: boolean;
+  onCheckedChange: () => void;
+  capitalize?: boolean;
+}
+
+function FilterOption({
+  id,
+  label,
+  checked,
+  onCheckedChange,
+  capitalize = false,
+}: FilterOptionProps) {
+  return (
+    <div className="flex items-center space-x-2 p-2 hover:bg-accent hover:text-accent-foreground">
+      <Checkbox id={id} checked={checked} onCheckedChange={onCheckedChange} />
+      <label
+        htmlFor={id}
+        className={`flex-grow text-sm cursor-pointer ${
+          capitalize ? "capitalize" : ""
+        }`}
+      >
+        {label}
+      </label>
+    </div>
+  );
+}
+
+interface FilterSectionProps {
+  label: string;
+  buttonText: string;
+  options: string[];
+  selectedOptions: string[];
+  onOptionChange: (value: string) => void;
+  capitalize?: boolean;
+  disabled?: boolean;
+}
+
+function FilterSection({
+  label,
+  buttonText,
+  options,
+  selectedOptions,
+  onOptionChange,
+  capitalize = false,
+  disabled = false,
+}: FilterSectionProps) {
+  return (
+    <div className="flex flex-col space-y-1.5">
+      <label
+        htmlFor={`${label.toLowerCase()}-filter`}
+        className="text-sm font-medium text-muted-foreground"
+      >
+        {label}
+      </label>
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button
+            id={`${label.toLowerCase()}-filter`}
+            variant="outline"
+            role="combobox"
+            className="w-full sm:w-[200px] justify-between"
+            disabled={disabled}
+          >
+            {buttonText}
+            <ChevronDownIcon className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        {!disabled && (
+          <PopoverContent className="w-full sm:w-[200px] p-0">
+            <div className="max-h-[300px] overflow-y-auto">
+              {options.map((option) => (
+                <FilterOption
+                  key={option}
+                  id={option}
+                  label={option}
+                  checked={selectedOptions.includes(option)}
+                  onCheckedChange={() => onOptionChange(option)}
+                  capitalize={capitalize}
+                />
+              ))}
+            </div>
+          </PopoverContent>
+        )}
+      </Popover>
+    </div>
+  );
+}
+
+interface PullRequestFilterProps {
+  uniqueRepositories: string[];
+  selectedRepoFilters: string[];
+  buildStatusFilter: string[];
+  onRepoFilterChange: (value: string) => void;
+  onBuildStatusFilterChange: (value: string) => void;
+}
+
+export function PullRequestFilter({
+  uniqueRepositories,
+  selectedRepoFilters,
+  buildStatusFilter,
+  onRepoFilterChange,
+  onBuildStatusFilterChange,
+}: PullRequestFilterProps) {
+  const buildStatusOptions = ["success", "failure", "pending", "unknown"];
+
+  return (
+    <div className="flex flex-col sm:flex-row gap-4">
+      <FilterSection
+        label="Repositories"
+        buttonText={
+          selectedRepoFilters.length === 0
+            ? "Filter Repositories"
+            : `${selectedRepoFilters.length} selected`
+        }
+        options={uniqueRepositories}
+        selectedOptions={selectedRepoFilters}
+        onOptionChange={onRepoFilterChange}
+        capitalize={false}
+        disabled={uniqueRepositories.length === 0}
+      />
+      <FilterSection
+        label="Build Status"
+        buttonText={
+          buildStatusFilter.length === 0
+            ? "Filter Build Status"
+            : `${buildStatusFilter.length} selected`
+        }
+        options={buildStatusOptions}
+        selectedOptions={buildStatusFilter}
+        onOptionChange={onBuildStatusFilterChange}
+        capitalize={true}
+        disabled={buildStatusOptions.length === 0}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Problem
Sometimes, it takes longer than I want to review my pull requests, especially when I need to look at certain repositories. This update aims to make it quicker and easier to find my PRs.

## Feature
This update adds simple filters to the frontend. Users can filter PRs by repository and build status. This helps narrow down the list, so it’s easier to focus on what matters. Specifically:

1. Repository Filter: See PRs from selected repositories.
2. Build Status Filter: Filter PRs by build status (e.g., success, failure, pending).

These filters make it easier to find PRs without adding extra complexity. This makes the review process smoother and quicker.

## Scope Limitations
This update does not include advanced features like sorting by multiple criteria, keyword searches, or backend changes. The goal is to keep it simple. More advanced features could come later, but they are not part of this update.

## Demo


https://github.com/user-attachments/assets/d30d8d57-2fd6-4edf-bb6b-39ca4b1b8256

